### PR TITLE
Autocompile / melpa compatibility

### DIFF
--- a/ob-glsl.el
+++ b/ob-glsl.el
@@ -1,4 +1,23 @@
+;;; ob-glsl.el --- description pending -*- lexical-binding: t; -*-
+
+(defcustom ob-glsl-make-command "cmake -G \"Ninja\" . && ninja"
+  "build command used when compiling ob-glsl"
+  :type 'string
+  :group 'ob-glsl)
+
 (require 'ob)
+
+;; setup
+(defun ob-glsl-compile ()
+  (let ((default-directory (file-name-directory load-file-name)))
+	(shell-command ob-glsl-make-command)
+	(load-file
+	 (concat default-directory
+			 (car (directory-files default-directory nil "^ob-glsl-module\\.\\(so\\|dll\\)$"))))
+	))
+(when (not (featurep 'ob-glsl-module))
+  (ob-glsl-compile))
+
 (require 'ob-glsl-module)
 
 (defvar org-babel-default-header-args:glsl
@@ -37,3 +56,4 @@ This function is called by `org-babel-execute-src-block'."
   (error "glsl does not support sessions"))
 
 (provide 'ob-glsl)
+;;; ob-glsl.el ends here

--- a/ob-glsl.el
+++ b/ob-glsl.el
@@ -13,7 +13,7 @@
 	(shell-command ob-glsl-make-command)
 	(load-file
 	 (concat default-directory
-			 (car (directory-files default-directory nil "^ob-glsl-module\\.\\(so\\|dll\\)$"))))
+			 (car (directory-files default-directory nil "^ob-glsl-module\\.\\(so\\|dll\\|dylib\\)$"))))
 	))
 (when (not (featurep 'ob-glsl-module))
   (ob-glsl-compile))


### PR DESCRIPTION
The following allows for loading this package via quelpa directly from .emacs as follows:
```elisp
(use-package glsl-mode)
(use-package ob-glsl
  :after glsl-mode
  :quelpa (ob-glsl
		   :fetcher github
		   :repo "finalpatch/ob-glsl"
		   :files ("*.el" "*.cpp" "*.hpp" "CMakeLists.txt" "*.h" "*.so"))
  :custom
  (org-babel-do-load-languages
   'org-babel-load-languages
   '((glsl . t))))
```
Obviously, replace `"finalpatch/ob-glsl"` with `"shizcow/ob-glsl"` for a working example.

Being able to load this package with quelpa makes it one step closer to being melpa-compatible and able to be loaded with a simple `(use-package ob-glsl)`.

### Note on cleanliness
I'm not particularly versed in writing emacs packages, so I probable made some big mistakes here. The provided changes aren't really intended as a final product, but as a push towards the eventual goal of making this package more accessible.