### PR TITLE
Fix Upside Down Image

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -100,7 +100,7 @@ int emacs_module_init (emacs_runtime *ert) noexcept {
     emacs_env* env = ert->get_environment (ert);
     try {
         init();
-        glbinding::Binding::initialize(nullptr);
+        glbinding::Binding::initialize(false);
     } catch (std::exception& e) {
         reportError(env, e);
     }

--- a/Main.cpp
+++ b/Main.cpp
@@ -82,8 +82,8 @@ emacs_value obGlslRun (emacs_env* env,
     std::vector<uint8_t> flippedPixels(width * 4 * height);
     for (int y = 0; y < height; ++y) {
         memcpy(flippedPixels.data() + y * width * 4,
-                    pixels.data() + (height - 1 - y) * width * 4,
-                    width * 4);
+			   pixels.data() + (height - 1 - y) * width * 4,
+			   width * 4);
     }
 
     auto surface = SDL_CreateRGBSurfaceFrom(flippedPixels.data(), width, height,

--- a/Main.cpp
+++ b/Main.cpp
@@ -78,7 +78,15 @@ emacs_value obGlslRun (emacs_env* env,
     glReadBuffer(GL_COLOR_ATTACHMENT0);
     glReadPixels(0,0,width,height,GL_RGBA,GL_UNSIGNED_BYTE,pixels.data());
 
-    auto surface = SDL_CreateRGBSurfaceFrom(pixels.data(), width, height,
+    // Flip the pixel data vertically
+    std::vector<uint8_t> flippedPixels(width * 4 * height);
+    for (int y = 0; y < height; ++y) {
+        memcpy(flippedPixels.data() + y * width * 4,
+                    pixels.data() + (height - 1 - y) * width * 4,
+                    width * 4);
+    }
+
+    auto surface = SDL_CreateRGBSurfaceFrom(flippedPixels.data(), width, height,
                                             32/*depth*/, width * 4/*pitch*/,
                                             0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000);
     IMG_SavePNG(surface, outputPath.data());


### PR DESCRIPTION
Flip pixel data to account for coordinate system mismatch-- GLSL has y=0 at bottom left, PNG has y=0 at top left

Additionally, this fixes a minor type error in `glbinding::Binding::initialize`